### PR TITLE
Fix response code check since pushgateway success response code changed from 202 to 200

### DIFF
--- a/src/main/java/com/banzaicloud/metrics/prometheus/client/exporter/PushGatewayWithTimestamp.java
+++ b/src/main/java/com/banzaicloud/metrics/prometheus/client/exporter/PushGatewayWithTimestamp.java
@@ -243,7 +243,7 @@ public class PushGatewayWithTimestamp {
             }
 
             int response = connection.getResponseCode();
-            if (response != HttpURLConnection.HTTP_ACCEPTED) {
+            if (response != HttpURLConnection.HTTP_OK) {
                 logger.info("Error response from " + url);
 
                 String errMsg = readErrorStream(connection);

--- a/src/main/java/com/banzaicloud/metrics/prometheus/client/exporter/PushGatewayWithTimestamp.java
+++ b/src/main/java/com/banzaicloud/metrics/prometheus/client/exporter/PushGatewayWithTimestamp.java
@@ -24,7 +24,10 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -74,6 +77,9 @@ public class PushGatewayWithTimestamp {
     private static final Logger logger = LoggerFactory.getLogger(PushGatewayWithTimestamp.class);
     private final String address;
     private static final int SECONDS_PER_MILLISECOND = 1000;
+    private static final List<Integer> ACCEPTED_STATUS_CODES = new ArrayList<Integer>(Arrays.asList(
+            HttpURLConnection.HTTP_OK,
+            HttpURLConnection.HTTP_ACCEPTED));
     /**
      * Construct a Pushgateway, with the given address.
      * <p>
@@ -243,7 +249,7 @@ public class PushGatewayWithTimestamp {
             }
 
             int response = connection.getResponseCode();
-            if (response != HttpURLConnection.HTTP_OK) {
+            if (!ACCEPTED_STATUS_CODES.contains(response)) {
                 logger.info("Error response from " + url);
 
                 String errMsg = readErrorStream(connection);


### PR DESCRIPTION

| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | no|yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | https://github.com/prometheus/pushgateway/pull/290
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Change response code check from HttpURLConnection. HTTP_ACCEPTED to HttpURLConnection.HTTP_OK since pushgateway success response code changed starting from version 0.10.0 

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Avoid throwing IOException when metrics are successfully sent to pushgateway 

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline (TODO)
- [ ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
