### PR TITLE
Fix PG address builder

### DIFF
--- a/src/main/scala/com/banzaicloud/spark/metrics/sink/PrometheusSink.scala
+++ b/src/main/scala/com/banzaicloud/spark/metrics/sink/PrometheusSink.scala
@@ -17,7 +17,7 @@
 package com.banzaicloud.spark.metrics.sink
 
 import java.io.File
-import java.net.{InetAddress, URI, UnknownHostException}
+import java.net.{InetAddress, URI, URL, UnknownHostException}
 import java.util
 import java.util.Properties
 import java.util.concurrent.TimeUnit
@@ -41,7 +41,7 @@ import scala.collection.JavaConverters._
 
 abstract class PrometheusSink(property: Properties,
                               registry: MetricRegistry,
-                              pushGatewayBuilder: String => PushGateway = new PushGateway(_),
+                              pushGatewayBuilder: URL => PushGateway = new PushGateway(_),
                               defaultSparkConf: SparkConf = new SparkConf(true)
                              )  extends Logging {
 
@@ -208,7 +208,7 @@ abstract class PrometheusSink(property: Properties,
 
   lazy val jmxMetrics = new SparkJmxExports(new JmxCollector(new File(jmxCollectorConfig)), labelsMap, pushTimestamp)
 
-  val pushGateway: PushGateway = pushGatewayBuilder(s"$pushGatewayAddressProtocol://$pushGatewayAddress")
+  val pushGateway: PushGateway = pushGatewayBuilder(new URL(s"$pushGatewayAddressProtocol://$pushGatewayAddress"))
 
   val reporter = new Reporter(registry)
 

--- a/src/test/scala/com/banzaicloud/spark/metrics/sink/PrometheusSinkSuite.scala
+++ b/src/test/scala/com/banzaicloud/spark/metrics/sink/PrometheusSinkSuite.scala
@@ -101,7 +101,7 @@ class PrometheusSinkSuite {
 
   }
 
-  class PushGatewayMock extends PushGateway("anything") {
+  class PushGatewayMock extends PushGateway(new java.net.URL("http://example.com")) {
     val requests = new CopyOnWriteArrayList[Request]().asScala
     case class Request(registry: CollectorRegistry, job: String, groupingKey: util.Map[String, String], method: String)
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
New version of PushGateway add http protocol to addres on its own. Therefore current address was pretended with `http://` twice.




### Checklist

- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline (TODO)
- [ ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)
