### PR TITLE
NO-TICKET - fix namespace substitution

### DIFF
--- a/src/main/scala/org/apache/spark/banzaicloud/metrics/sink/PrometheusSink.scala
+++ b/src/main/scala/org/apache/spark/banzaicloud/metrics/sink/PrometheusSink.scala
@@ -1,12 +1,47 @@
 package org.apache.spark.banzaicloud.metrics.sink
 
+import java.net.URL
 import java.util.Properties
 
+import com.banzaicloud.spark.metrics.sink.PrometheusSink.SinkConfig
 import com.codahale.metrics.MetricRegistry
-import org.apache.spark.SecurityManager
+import io.prometheus.client.exporter.PushGateway
+import org.apache.spark.banzaicloud.metrics.sink.PrometheusSink.SinkConfigProxy
+import org.apache.spark.internal.config
 import org.apache.spark.metrics.sink.Sink
+import org.apache.spark.{SecurityManager, SparkConf, SparkEnv}
 
-class PrometheusSink(val property: Properties,
-                     val registry: MetricRegistry,
-                     val securityMgr: SecurityManager)
-  extends com.banzaicloud.spark.metrics.sink.PrometheusSink(property, registry) with Sink
+object PrometheusSink {
+
+  class SinkConfigProxy extends SinkConfig {
+    // SparkEnv may become available only after metrics sink creation thus retrieving
+    // SparkConf from spark env here and not during the creation/initialisation of PrometheusSink.
+    @transient
+    private lazy val sparkConfig = Option(SparkEnv.get).map(_.conf).getOrElse(new SparkConf(true))
+
+    // Don't use sparkConf.getOption("spark.metrics.namespace") as the underlying string won't be substituted.
+    def metricsNamespace: Option[String] = sparkConfig.get(config.METRICS_NAMESPACE)
+    def sparkAppId: Option[String] = sparkConfig.getOption("spark.app.id")
+    def sparkAppName: Option[String] = sparkConfig.getOption("spark.app.name")
+    def executorId: Option[String] = sparkConfig.getOption("spark.executor.id")
+  }
+}
+
+class PrometheusSink(property: Properties,
+                     registry: MetricRegistry,
+                     securityMgr: SecurityManager,
+                     sinkConfig: SinkConfig,
+                     pushGatewayBuilder: URL => PushGateway)
+  extends com.banzaicloud.spark.metrics.sink.PrometheusSink(property, registry, sinkConfig, pushGatewayBuilder) with Sink {
+
+  // Constructor required by MetricsSystem::registerSinks()
+  def this(property: Properties, registry: MetricRegistry, securityMgr: SecurityManager) = {
+    this(
+      property,
+      registry,
+      securityMgr,
+      new SinkConfigProxy,
+      new PushGateway(_)
+    )
+  }
+}

--- a/src/test/scala/com/banzaicloud/spark/metrics/sink/PrometheusSinkSuite.scala
+++ b/src/test/scala/com/banzaicloud/spark/metrics/sink/PrometheusSinkSuite.scala
@@ -5,33 +5,37 @@ import java.util
 import java.util.Properties
 import java.util.concurrent.CopyOnWriteArrayList
 
+import com.banzaicloud.spark.metrics.sink.PrometheusSink.SinkConfig
 import com.codahale.metrics.MetricRegistry
 import io.prometheus.client.CollectorRegistry
 import io.prometheus.client.exporter.PushGateway
-import org.apache.spark.SparkConf
+import org.apache.spark.banzaicloud.metrics.sink.{PrometheusSink => SparkPrometheusSink}
 import org.junit.{Assert, Test}
 
 import scala.collection.JavaConverters._
 import scala.util.Try
 
 class PrometheusSinkSuite {
+  case class TestSinkConfig(metricsNamespace: Option[String],
+                            sparkAppId: Option[String],
+                            sparkAppName: Option[String],
+                            executorId: Option[String]) extends SinkConfig
+
+  private val properties = new Properties
+  properties.setProperty("enable-jmx-collector", "true")
+  properties.setProperty("labels", "a=1,b=22")
+  properties.setProperty("period", "1")
+  properties.setProperty("group-key", "key1=AA,key2=BB")
+  properties.setProperty("jmx-collector-config", "/dev/null")
+
   trait Fixture {
+    def sinkConfig = TestSinkConfig(Some("test-job-name"), Some("test-app-id"), Some("test-app-name"), None)
     lazy val pgMock = new PushGatewayMock
     lazy val registry = new MetricRegistry
-    val sparkConf = new SparkConf(true)
-      .set("spark.app.id", "test-app-id")
-      .set("spark.app.name", "test-app-name")
-      .set("spark.metrics.namespace", "test-job-name")
-    val properties = new Properties
-    properties.setProperty("enable-jmx-collector", "true")
-    properties.setProperty("labels", "a=1,b=22")
-    properties.setProperty("period", "1")
-    properties.setProperty("group-key", "key1=AA,key2=BB")
-    properties.setProperty("jmx-collector-config", "/dev/null")
 
-    def withSink[T](fn: (PrometheusSink) => T): Unit = {
+    def withSink[T](fn: (SparkPrometheusSink) => T): Unit = {
       // Given
-      val sink = new PrometheusSinkImpl(properties, registry, pgMock, sparkConf)
+      val sink = new SparkPrometheusSink(properties, registry, null, sinkConfig, _ => pgMock)
       try {
       //When
         sink.start()
@@ -45,8 +49,7 @@ class PrometheusSinkSuite {
   @Test
   def testSinkForDriver(): Unit = new Fixture {
     //Given
-    sparkConf
-      .set("spark.executor.id", "driver")
+    override val sinkConfig = super.sinkConfig.copy(executorId = Some("driver"))
 
     registry.counter("test-counter").inc(3)
     withSink { sink =>
@@ -66,9 +69,7 @@ class PrometheusSinkSuite {
   @Test
   def testSinkForExecutor(): Unit = new Fixture {
     //Given
-    sparkConf
-      .set("spark.executor.id", "executor")
-      .set("spark.executor.id", "2")
+    override val sinkConfig = super.sinkConfig.copy(executorId = Some("2"))
 
     registry.counter("test-counter").inc(3)
 
@@ -93,15 +94,7 @@ class PrometheusSinkSuite {
     }
   }
 
-  class PrometheusSinkImpl(property: Properties,
-                            registry: MetricRegistry,
-                            pushGateway: PushGateway,
-                            sparkConf: SparkConf)
-    extends PrometheusSink(property, registry, _ => pushGateway, sparkConf) {
-
-  }
-
-  class PushGatewayMock extends PushGateway(new java.net.URL("http://example.com")) {
+  class PushGatewayMock extends PushGateway("anything") {
     val requests = new CopyOnWriteArrayList[Request]().asScala
     case class Request(registry: CollectorRegistry, job: String, groupingKey: util.Map[String, String], method: String)
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
Slightly refactored the way how we get data from sparkConfig. I have a plan to create a PR with bigger refactor where sparkConfig and properties values will be handled by separate class. But for the purpose of the bug fix I decide to do the minimal change.

### Why?
Fix regression to obtaining `spark.metrics.namespace`. In the previous versions we were using 
typed `private[spark] sparkConfig.getConfig[T]` (`sparkConfig.get(config.METRICS_NAMESPACE)`). It was private but in spark jars embedded in the repository it was "uncovered". In the most recent version we don't use custom jars so I changed the code to use untyped `sparkConfig.getOption('spark.metrics.namespace')`
However, there is a small difference between `getConfig[T]` and `getOption`. The first one do the variable substitution where the second one doesn't. So now if 'spark.metrics.namespace' is set to `"${spark.app.name}` it won't be substituted.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
