### PR TITLE
Do not bring spark-core with dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,11 +22,9 @@ lazy val root = (project in file("."))
       "io.prometheus" % "simpleclient" % "0.8.1",
       "io.prometheus" % "simpleclient_dropwizard" % "0.8.1",
       "io.prometheus" % "simpleclient_pushgateway" % "0.8.1",
-      "io.dropwizard.metrics" % "metrics-core" % "3.1.2",
-      "org.slf4j" % "slf4j-api" % "1.7.16",
-      "com.google.guava" % "guava" % "26.0-android",
+      "io.dropwizard.metrics" % "metrics-core" % "3.1.5",
       "io.prometheus.jmx" % "collector" % "0.12.0",
-      "org.apache.spark" %% "spark-core" % "2.4.4",
+      "org.apache.spark" %% "spark-core" % "2.4.4" % Provided,
       "com.novocode" % "junit-interface" % "0.11" % Test,
       // Spark shaded jetty is not resolved in scala 2.11
       // Described in https://issues.apache.org/jira/browse/SPARK-18162?focusedCommentId=15818123#comment-15818123

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.16
+sbt.version = 1.3.8


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?

Improve build.sbt

* Set `spark-core` dependency configuration to "Provided"
* Remove unnecessary explicit dependencies (Guava, Slf4j)
* Update SBT version to 1.3.8

### Why?

Hello. I'm trying to use your library but I noticed that you have a direct dependency on `spark-core ` in your build settings. This brings ~45 MB of classes when I package a project (we use sbt-assembly to build fat jars that are submitted to Spark).

I simply changed its configuration to "Provided " and removed explicit dependencies that serve no purpose here (if you want a specific version of Guava and Slf4j, this is not a good place).

I also bumped the SBT version since that's what I use internally, but you can safely revert that if you still need 0.13 for some reason.

### Checklist

Not applicable.