### PR TITLE
migrate build to spark 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,5 @@
-lazy val scala212 = "2.12.10"
-lazy val scala211 = "2.11.12"
-lazy val supportedScalaVersions = List(scala212, scala211)
+lazy val scala212 = "2.12.12"
+lazy val supportedScalaVersions = List(scala212)
 
 lazy val root = (project in file("."))
   .settings(
@@ -17,18 +16,18 @@ lazy val root = (project in file("."))
     licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0")),
     scalaVersion := scala212,
     crossScalaVersions := supportedScalaVersions,
-    version      := "2.4-1.0.6",
+    version      := "3.0-1.1.0",
     libraryDependencies ++= Seq(
-      "io.prometheus" % "simpleclient" % "0.8.1",
-      "io.prometheus" % "simpleclient_dropwizard" % "0.8.1",
-      "io.prometheus" % "simpleclient_pushgateway" % "0.8.1",
-      "io.dropwizard.metrics" % "metrics-core" % "3.1.5",
-      "io.prometheus.jmx" % "collector" % "0.12.0",
-      "org.apache.spark" %% "spark-core" % "2.4.4" % Provided,
+      "io.prometheus" % "simpleclient" % "0.9.0",
+      "io.prometheus" % "simpleclient_dropwizard" % "0.9.0",
+      "io.prometheus" % "simpleclient_pushgateway" % "0.9.0",
+      "io.dropwizard.metrics" % "metrics-core" % "4.1.1" % Provided,
+      "io.prometheus.jmx" % "collector" % "0.14.0",
+      "org.apache.spark" %% "spark-core" % "3.0.1" % Provided,
       "com.novocode" % "junit-interface" % "0.11" % Test,
-      // Spark shaded jetty is not resolved in scala 2.11
-      // Described in https://issues.apache.org/jira/browse/SPARK-18162?focusedCommentId=15818123#comment-15818123
-      "org.eclipse.jetty" % "jetty-servlet"  % "9.4.18.v20190429" % Test
+//      // Spark shaded jetty is not resolved in scala 2.11
+//      // Described in https://issues.apache.org/jira/browse/SPARK-18162?focusedCommentId=15818123#comment-15818123
+//      "org.eclipse.jetty" % "jetty-servlet"  % "9.4.18.v20190429" % Test
     ),
     testOptions in Test := Seq(Tests.Argument(TestFrameworks.JUnit, "-a"))
   )


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #42 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Migrates the build to Spark 3

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Spark 3 is stable for more than a year now. Let's add support

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] Do we want to continue support for Spark 2.4? Because then a cross-build would be a better approach.
