### PR TITLE
Upgrade Spark version to 3.1.2

### DIFF
--- a/PrometheusSink.md
+++ b/PrometheusSink.md
@@ -115,6 +115,12 @@ Also we have to specify the spark-metrics package that includes PrometheusSink a
 ```sh
 --packages com.banzaicloud:spark-metrics_2.11:2.3-2.1.0,io.prometheus:simpleclient:0.3.0,io.prometheus:simpleclient_dropwizard:0.3.0,io.prometheus:simpleclient_pushgateway:0.3.0,io.dropwizard.metrics:metrics-core:3.1.2
 ```
+
+* Spark 3.1:
+
+```sh
+--packages com.banzaicloud:spark-metrics_2.12:3.1-1.0.0,io.prometheus:simpleclient:0.11.0,io.prometheus:simpleclient_dropwizard:0.11.0,io.prometheus:simpleclient_pushgateway:0.11.0,io.prometheus:simpleclient_common:0.11.0,io.prometheus.jmx:collector:0.15.0
+```
 _**Note**_: the `--packages` option currently is not supported by _**Spark 2.3 when running on Kubernetes**_. The reason is that the `--packages` option behind the scenes downloads the files from maven repo to local machines than uploads these to the cluster using _Local File Dependency Management_ feature. This feature has not been backported from the _**Spark 2.2 on Kubernetes**_ fork to _**Spark 2.3**_. See details here: [Spark 2.3 Future work](https://spark.apache.org/docs/latest/running-on-kubernetes.html#future-work). This can be worked around by:
 1. building ourselves [Spark 2.3 with Kubernetes support](https://spark.apache.org/docs/latest/building-spark.html#building-with-kubernetes-support) from source
 1. downloading and adding the dependencies to `assembly/target/scala-2.11/jars` folder, by running the following commands:

--- a/build.sbt
+++ b/build.sbt
@@ -16,18 +16,19 @@ lazy val root = (project in file("."))
     licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0")),
     scalaVersion := scala212,
     crossScalaVersions := supportedScalaVersions,
-    version      := "3.0-1.1.0",
+    version      := "3.1-1.0.0",
     libraryDependencies ++= Seq(
-      "io.prometheus" % "simpleclient" % "0.9.0",
-      "io.prometheus" % "simpleclient_dropwizard" % "0.9.0",
-      "io.prometheus" % "simpleclient_pushgateway" % "0.9.0",
+      "io.prometheus" % "simpleclient" % "0.11.0",
+      "io.prometheus" % "simpleclient_dropwizard" % "0.11.0",
+      "io.prometheus" % "simpleclient_common" % "0.11.0",
+      "io.prometheus" % "simpleclient_pushgateway" % "0.11.0",
       "io.dropwizard.metrics" % "metrics-core" % "4.1.1" % Provided,
-      "io.prometheus.jmx" % "collector" % "0.14.0",
-      "org.apache.spark" %% "spark-core" % "3.0.1" % Provided,
+      "io.prometheus.jmx" % "collector" % "0.15.0",
+      "org.apache.spark" %% "spark-core" % "3.1.2" % Provided,
       "com.novocode" % "junit-interface" % "0.11" % Test,
-//      // Spark shaded jetty is not resolved in scala 2.11
-//      // Described in https://issues.apache.org/jira/browse/SPARK-18162?focusedCommentId=15818123#comment-15818123
-//      "org.eclipse.jetty" % "jetty-servlet"  % "9.4.18.v20190429" % Test
+      // Spark shaded jetty is not resolved in scala 2.11
+      // Described in https://issues.apache.org/jira/browse/SPARK-18162?focusedCommentId=15818123#comment-15818123
+      // "org.eclipse.jetty" % "jetty-servlet"  % "9.4.18.v20190429" % Test
     ),
     testOptions in Test := Seq(Tests.Argument(TestFrameworks.JUnit, "-a"))
   )


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | #75
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Upgrade Spark to a more mature version (3.1.2), update Prometheus versions, add missed jars that needed for runtime.
Please, also see PR https://github.com/banzaicloud/spark-metrics/pull/75

Since there isn't Spark 3 Maven release we can update it to a newer version. I hope Spark 3 Maven artifact will be published soon, so other people can use it.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Tried to use spark-metrics with Spark 3.1.2 and faced problems with dependencies.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
