### PR TITLE
Add sbt assembly support

### DIFF
--- a/PrometheusSink.md
+++ b/PrometheusSink.md
@@ -125,7 +125,6 @@ _**Note**_: the `--packages` option currently is not supported by _**Spark 2.3 w
    1. mvn dependency:copy-dependencies -f ~/.m2/repository/com/banzaicloud/spark-metrics_2.11/${SPARK_METRICS_VERSION}/spark-metrics_2.11-${SPARK_METRICS_VERSION}.pom -DoutputDirectory=$(pwd)/temp
    1. cp temp/* assembly/target/scala-2.11/jars
    
-
 ### Build fat jar
 In the case when you want to add spark-metrics jar into your classpath you can build it locally to include all needed dependencies using the following command: 
 ```sh

--- a/PrometheusSink.md
+++ b/PrometheusSink.md
@@ -124,6 +124,14 @@ _**Note**_: the `--packages` option currently is not supported by _**Spark 2.3 w
    1. mkdir temp
    1. mvn dependency:copy-dependencies -f ~/.m2/repository/com/banzaicloud/spark-metrics_2.11/${SPARK_METRICS_VERSION}/spark-metrics_2.11-${SPARK_METRICS_VERSION}.pom -DoutputDirectory=$(pwd)/temp
    1. cp temp/* assembly/target/scala-2.11/jars
+   
+
+### Build fat jar
+In the case when you want to add spark-metrics jar into your classpath you can build it locally to include all needed dependencies using the following command: 
+```sh
+sbt assembly
+```
+After assembling just add resulting ``spark-metrics-assembly-3.1-1.0.0.jar`` into your Spark classpath (e.g. `$SPARK_HOME/jars/`).
 
 #### Package version
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,3 +4,4 @@ resolvers += "sonatype-releases" at "https://oss.sonatype.org/content/repositori
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0-M2")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.0.0")


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | #74
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Add sbt assembly plugin to be able to build fat jar locally with all needed dependencies to include it to Spark classpath

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Sometimes it's not convenient to use `--packages` with spark-submit command but just include a fat jar with all needed dependencies to classpath might be much simpler.

Related PR: https://github.com/banzaicloud/spark-metrics/pull/74 (I have added simpleclient_common to dependencies since it needed for simpleclient_pushgateway and simpleclient)


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
