### PR TITLE
Updating spark dependencies to 3.2 versions and updating prometheus sink constuctor

### DIFF
--- a/PrometheusSink.md
+++ b/PrometheusSink.md
@@ -121,6 +121,12 @@ Also we have to specify the spark-metrics package that includes PrometheusSink a
 ```sh
 --packages com.banzaicloud:spark-metrics_2.12:3.1-1.0.0,io.prometheus:simpleclient:0.11.0,io.prometheus:simpleclient_dropwizard:0.11.0,io.prometheus:simpleclient_pushgateway:0.11.0,io.prometheus:simpleclient_common:0.11.0,io.prometheus.jmx:collector:0.15.0
 ```
+
+* Spark 3.2:
+
+```sh
+--packages com.banzaicloud:spark-metrics_2.12:3.2-1.0.0,io.prometheus:simpleclient:0.15.0,io.prometheus:simpleclient_dropwizard:0.15.0,io.prometheus:simpleclient_pushgateway:0.15.0,io.prometheus:simpleclient_common:0.15.0,io.prometheus.jmx:collector:0.17.0
+```
 _**Note**_: the `--packages` option currently is not supported by _**Spark 2.3 when running on Kubernetes**_. The reason is that the `--packages` option behind the scenes downloads the files from maven repo to local machines than uploads these to the cluster using _Local File Dependency Management_ feature. This feature has not been backported from the _**Spark 2.2 on Kubernetes**_ fork to _**Spark 2.3**_. See details here: [Spark 2.3 Future work](https://spark.apache.org/docs/latest/running-on-kubernetes.html#future-work). This can be worked around by:
 1. building ourselves [Spark 2.3 with Kubernetes support](https://spark.apache.org/docs/latest/building-spark.html#building-with-kubernetes-support) from source
 1. downloading and adding the dependencies to `assembly/target/scala-2.11/jars` folder, by running the following commands:
@@ -136,7 +142,7 @@ In the case when you want to add spark-metrics jar into your classpath you can b
 ```sh
 sbt assembly
 ```
-After assembling just add resulting ``spark-metrics-assembly-3.1-1.0.0.jar`` into your Spark classpath (e.g. `$SPARK_HOME/jars/`).
+After assembling just add resulting ``spark-metrics-assembly-3.2-1.0.0.jar`` into your Spark classpath (e.g. `$SPARK_HOME/jars/`).
 
 #### Package version
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,6 @@
 lazy val scala212 = "2.12.12"
 lazy val supportedScalaVersions = List(scala212)
+lazy val ioPrometheusVersion = "0.15.0"
 
 lazy val root = (project in file("."))
   .settings(
@@ -16,20 +17,20 @@ lazy val root = (project in file("."))
     licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0")),
     scalaVersion := scala212,
     crossScalaVersions := supportedScalaVersions,
-    version      := "3.1-1.0.0",
+    version      := "3.2-1.0.0",
     libraryDependencies ++= Seq(
-      "io.prometheus" % "simpleclient" % "0.11.0",
-      "io.prometheus" % "simpleclient_dropwizard" % "0.11.0",
-      "io.prometheus" % "simpleclient_common" % "0.11.0",
-      "io.prometheus" % "simpleclient_pushgateway" % "0.11.0",
-      "io.dropwizard.metrics" % "metrics-core" % "4.1.1" % Provided,
-      "io.prometheus.jmx" % "collector" % "0.15.0",
-      "org.apache.spark" %% "spark-core" % "3.1.2" % Provided,
+      "io.prometheus" % "simpleclient" % ioPrometheusVersion,
+      "io.prometheus" % "simpleclient_dropwizard" % ioPrometheusVersion,
+      "io.prometheus" % "simpleclient_common" % ioPrometheusVersion,
+      "io.prometheus" % "simpleclient_pushgateway" % ioPrometheusVersion,
+      "io.dropwizard.metrics" % "metrics-core" % "4.2.9" % Provided,
+      "io.prometheus.jmx" % "collector" % "0.17.0",
+      "org.apache.spark" %% "spark-core" % "3.2.1" % Provided,
       "com.novocode" % "junit-interface" % "0.11" % Test,
       // Spark shaded jetty is not resolved in scala 2.11
       // Described in https://issues.apache.org/jira/browse/SPARK-18162?focusedCommentId=15818123#comment-15818123
       // "org.eclipse.jetty" % "jetty-servlet"  % "9.4.18.v20190429" % Test
-    ),
+      ),
     testOptions in Test := Seq(Tests.Argument(TestFrameworks.JUnit, "-a"))
   )
 

--- a/src/main/scala/org/apache/spark/banzaicloud/metrics/sink/PrometheusSink.scala
+++ b/src/main/scala/org/apache/spark/banzaicloud/metrics/sink/PrometheusSink.scala
@@ -4,7 +4,7 @@ import java.net.URL
 import java.util.Properties
 
 import com.banzaicloud.spark.metrics.sink.PrometheusSink.SinkConfig
-import com.codahale.metrics.{MetricFilter, MetricRegistry}
+import com.codahale.metrics.{MetricRegistry}
 import io.prometheus.client.exporter.PushGateway
 import org.apache.spark.banzaicloud.metrics.sink.PrometheusSink.SinkConfigProxy
 import org.apache.spark.internal.config
@@ -29,20 +29,23 @@ object PrometheusSink {
 
 class PrometheusSink(property: Properties,
                      registry: MetricRegistry,
-                     securityMgr: SecurityManager,
                      sinkConfig: SinkConfig,
                      pushGatewayBuilder: URL => PushGateway
                     )
   extends com.banzaicloud.spark.metrics.sink.PrometheusSink(property, registry, sinkConfig, pushGatewayBuilder) with Sink {
 
-  // Constructor required by MetricsSystem::registerSinks()
-  def this(property: Properties, registry: MetricRegistry, securityMgr: SecurityManager) = {
+  // Constructor required by MetricsSystem::registerSinks() for spark >= 3.2
+  def this(property: Properties, registry: MetricRegistry) = {
     this(
       property,
       registry,
-      securityMgr,
       new SinkConfigProxy,
       new PushGateway(_)
-    )
+      )
+  }
+
+  // Legacy Constructor required by MetricsSystem::registerSinks() for spark < 3.2
+  def this(property: Properties, registry: MetricRegistry, securityMgr: SecurityManager) = {
+    this(property, registry)
   }
 }

--- a/src/test/scala/com/banzaicloud/spark/metrics/sink/PrometheusSinkSuite.scala
+++ b/src/test/scala/com/banzaicloud/spark/metrics/sink/PrometheusSinkSuite.scala
@@ -41,7 +41,7 @@ class PrometheusSinkSuite {
 
     def withSink[T](properties: Properties = basicProperties)(fn: (SparkPrometheusSink) => T): Unit = {
       // Given
-      val sink = new SparkPrometheusSink(properties, registry, null, sinkConfig, _ => pgMock)
+      val sink = new SparkPrometheusSink(properties, registry, sinkConfig, _ => pgMock)
       try {
       //When
         sink.start()

--- a/src/test/scala/org/apache/spark/banzaicloud/metrics/sink/PrometheusSinkSuite.scala
+++ b/src/test/scala/org/apache/spark/banzaicloud/metrics/sink/PrometheusSinkSuite.scala
@@ -1,7 +1,7 @@
 package org.apache.spark.banzaicloud.metrics.sink
 
 import org.apache.spark.metrics.MetricsSystem
-import org.apache.spark.{SecurityManager, SparkConf}
+import org.apache.spark.{SparkConf}
 import org.junit.{After, Before, Test}
 
 class PrometheusSinkSuite {
@@ -12,8 +12,7 @@ class PrometheusSinkSuite {
   def testThatPrometheusSinkCanBeLoaded() = {
     val instance = "driver"
     val conf = new SparkConf(true)
-    val sm = new SecurityManager(conf)
-    val ms = MetricsSystem.createMetricsSystem(instance, conf, sm)
+    val ms = MetricsSystem.createMetricsSystem(instance, conf)
     ms.start()
     ms.stop()
   }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?             | yes
| New feature?    | no
| API breaks?       | no
| Deprecations?   | no
| Related tickets  | n/a
| License              | Apache 2.0

### What's in this PR?
Updated the library to support spark 3.2. Also updated the other dependencies to more recent versions.

### Why?
The spark 3.2 metrics system changed the constructor for sinks to no longer look for a constructor with a security manager, so I added new constructor without the security manager (which wasn't used previously anyway).  I left the older constructor in place to maintain backwards compatibility, but it just calls the new constructor.

### Checklist
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)

